### PR TITLE
Typo Fixed in stop function

### DIFF
--- a/lib/src/clipboard_watcher.dart
+++ b/lib/src/clipboard_watcher.dart
@@ -55,7 +55,7 @@ class ClipboardWatcher {
   }
 
   Future<void> stop() async {
-    await _channel.invokeMethod('start');
+    await _channel.invokeMethod('stop');
   }
 }
 


### PR DESCRIPTION
Typo in stop function. _channel.invokeMethod('start');  to  _channel.invokeMethod('stop');