### PR TITLE
Issue building with gradle version >= 8.x.x

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'dev.leanflutter.clipboard_watcher'
     compileSdkVersion 33
 
     compileOptions {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
-<manifest package="clipboard.watcher">
+<manifest package="dev.leanflutter.clipboard_watcher">
 </manifest>


### PR DESCRIPTION
Reference: https://stackoverflow.com/questions/76108428/how-do-i-fix-namespace-not-specified-error-in-android-studio